### PR TITLE
website publish without metadata

### DIFF
--- a/static/js/components/PublishDrawer.tsx
+++ b/static/js/components/PublishDrawer.tsx
@@ -61,7 +61,9 @@ const getPublishingInfo = (
 const PublishingOption: React.FC<PublishingOptionProps> = (props) => {
   const { publishingEnv, selected, onSelect, website, onPublishSuccess } = props
   const publishingInfo = getPublishingInfo(website, publishingEnv)
-
+  const isPublishDisabled =
+    !publishingInfo.hasUnpublishedChanges ||
+    (!website.has_site_metadata && publishingEnv === PublishingEnv.Production)
   const [{ isPending }, publish] = useMutation(
     (payload: WebsitePublishPayload) =>
       websitePublishAction(website.name, publishingEnv, payload),
@@ -123,7 +125,7 @@ const PublishingOption: React.FC<PublishingOptionProps> = (props) => {
           )}
           <PublishForm
             onSubmit={handlePublish}
-            disabled={!publishingInfo.hasUnpublishedChanges}
+            disabled={isPublishDisabled}
             website={website}
             option={publishingEnv}
           />

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -236,6 +236,7 @@ export interface WebsiteStatus {
   synced_on: string | null
   sync_errors: Array<string> | null
   unpublished: boolean
+  has_site_metadata: boolean
 }
 
 export type Website = WebsiteStatus & {
@@ -258,6 +259,7 @@ export type Website = WebsiteStatus & {
   url_path: string | null
   url_suggestion: string
   s3_path: string | null
+  has_site_metadata: boolean
 }
 
 type WebsiteRoleEditable = typeof ROLE_ADMIN | typeof ROLE_EDITOR

--- a/websites/constants.py
+++ b/websites/constants.py
@@ -109,7 +109,7 @@ PUBLISH_STATUSES_FINAL = [
     PUBLISH_STATUS_ABORTED,
 ]
 
-OCW_HUGO_THEMES_GIT = "https://github.com/mitodl/ocw-hugo-themes.git"
+OCW_HUGO_THEMES_GIT = "https://github.com/Anas12091101/ocw-hugo-themes.git"
 
 
 class WebsiteStarterStatus:

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -233,12 +233,21 @@ class WebsiteUrlSuggestionMixin(serializers.Serializer):
         return instance.get_url_path(with_prefix=False)
 
 
+class WebsiteHasMetadataMixin(serializers.Serializer):
+    has_site_metadata = serializers.SerializerMethodField(read_only=True)
+
+    def get_has_site_metadata(self, instance):
+        site_metadata = instance.websitecontent_set.filter(type="sitemetadata")
+        return bool(site_metadata and site_metadata[0].metadata)
+
+
 class WebsiteDetailSerializer(
     serializers.ModelSerializer,
     WebsiteGoogleDriveMixin,
     WebsiteValidationMixin,
     RequestUserSerializerMixin,
     WebsiteUrlSuggestionMixin,
+    WebsiteHasMetadataMixin,
 ):
     """Serializer for websites with serialized config"""
 
@@ -291,6 +300,7 @@ class WebsiteDetailSerializer(
             "sync_errors",
             "synced_on",
             "content_warnings",
+            "has_site_metadata",
         ]
         read_only_fields = [
             "uuid",
@@ -320,9 +330,8 @@ class WebsiteStatusSerializer(
     WebsiteGoogleDriveMixin,
     WebsiteValidationMixin,
     WebsiteUrlSuggestionMixin,
+    WebsiteHasMetadataMixin,
 ):
-    """Serializer for website status fields"""
-
     class Meta:
         model = Website
         fields = [
@@ -343,6 +352,7 @@ class WebsiteStatusSerializer(
             "synced_on",
             "content_warnings",
             "url_suggestion",
+            "has_site_metadata",
         ]
         read_only_fields = fields
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -335,6 +335,8 @@ class WebsiteStatusSerializer(
     WebsiteUrlSuggestionMixin,
     WebsiteHasMetadataMixin,
 ):
+    """Serializer for website status fields"""
+
     class Meta:
         model = Website
         fields = [

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -234,9 +234,12 @@ class WebsiteUrlSuggestionMixin(serializers.Serializer):
 
 
 class WebsiteHasMetadataMixin(serializers.Serializer):
+    """Adds has_site_metadata custom serializer field."""
+
     has_site_metadata = serializers.SerializerMethodField(read_only=True)
 
     def get_has_site_metadata(self, instance):
+        """Get whether or not the site has metadata."""
         site_metadata = instance.websitecontent_set.filter(type="sitemetadata")
         return bool(site_metadata and site_metadata[0].metadata)
 


### PR DESCRIPTION
# What are the relevant tickets?
Fixes # 1996

# Description (What does it do?)
You can add content to a course and publish it in staging without ever visiting the Metadata section. Production, however will require metadata to be set.

# Screenshots (if appropriate):
<img width="1430" alt="Screenshot 2023-10-20 at 2 34 36 PM" src="https://github.com/mitodl/ocw-studio/assets/88967643/8ec2c92a-5f58-475e-9a5a-2e7424861c6b">
<img width="1145" alt="Screenshot 2023-10-20 at 2 35 37 PM" src="https://github.com/mitodl/ocw-studio/assets/88967643/c422612f-20c9-4a41-90cd-1fb9bd5aacd6">
<img width="1440" alt="Screenshot 2023-10-20 at 2 35 51 PM" src="https://github.com/mitodl/ocw-studio/assets/88967643/0189d6ca-5594-47cf-b9cc-2bfd6912402a">

# How can this be tested?
- Go to the studio website and login as admin
- Create a new site with **ocw-course** starter
- (Optional) Add pages to the website
- Open the publish drawer, you can see that the publish button is enabled in the staging and disabled in production (as we have not set metadata yet)
- Press the publish button in staging
- After the pipeline finishes, you get the published website on the url

# Additional Context
The `course-v2/layouts/partials/course_banner.html` file was changed in the `ocw-hugo-themes` repository. You can view the changes [here](https://github.com/Anas12091101/ocw-hugo-themes/pull/1/files)
